### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Loads markdown files from a local folder or git repository and serves them as [M
 
 Useful for loading prompts from various sources and formats into your MCP-enabled applications, and sharing prompts across organizations.
 
+<a href="https://glama.ai/mcp/servers/@DiscreteTom/shinkuro">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@DiscreteTom/shinkuro/badge" alt="Shinkuro MCP server" />
+</a>
+
 ## Usage
 
 **IMPORTANT**: make sure your MCP client supports the MCP Prompts capability. See the [feature support matrix](https://modelcontextprotocol.io/clients#feature-support-matrix).


### PR DESCRIPTION
This PR adds a badge for the [Shinkuro](https://glama.ai/mcp/servers/@DiscreteTom/shinkuro) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@DiscreteTom/shinkuro">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@DiscreteTom/shinkuro/badge" alt="Shinkuro MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.